### PR TITLE
insert whitespace in output of ensemble model

### DIFF
--- a/utils/model_training.py
+++ b/utils/model_training.py
@@ -361,7 +361,7 @@ class import_and_train_model:
 
             output_label = output_label.tolist()
 
-            To_write = [i + '------------------' + j + '\n' for i, j in zip(im_names[0], output_label)]
+            To_write = [i + '------------------ ' + j + '\n' for i, j in zip(im_names[0], output_label)]
             np.savetxt(test_main.params.test_outpath + '/Single_model_Plankiformer_predictions.txt', To_write, fmt='%s')
 
     def run_ensemble_prediction_on_unseen(self, test_main, data_loader, name):
@@ -410,7 +410,7 @@ class import_and_train_model:
 
         Ens_DEIT_label = Ens_DEIT_label.tolist()
 
-        To_write = [i + '------------------' + j + '\n' for i, j in zip(im_names[0], Ens_DEIT_label)]
+        To_write = [i + '------------------ ' + j + '\n' for i, j in zip(im_names[0], Ens_DEIT_label)]
         np.savetxt(test_main.params.test_outpath + '/Ensemble_models_Plankiformer_predictions_' + name2 + name + '.txt', To_write, fmt='%s')
 
     def initialize_model(self, train_main, test_main, data_loader, lr):


### PR DESCRIPTION
Hi Sreenath,
for consistency with other tools changed '-------taxa_' to '------ taxa_'
Note that the final '_' is present in your class labels (Phytoformer/classes.npy)
Maybe you want to edit those labels to make cleaner?